### PR TITLE
Fix for never ending recursion

### DIFF
--- a/lib/class.subsectionmanager.php
+++ b/lib/class.subsectionmanager.php
@@ -185,11 +185,12 @@
 
 							// Get value
 							if (!isset($cache[$entry['id']][$field_id])) {
+								$cache[$entry['id']][$field_id] = '';
 								if(is_callable(array($field, 'preparePlainTextValue'))) {
-									$field_value = $field->preparePlainTextValue($entry['data'][$field_id], $entry['id']);
+									$field_value = $cache[$entry['id']][$field_id] = $field->preparePlainTextValue($entry['data'][$field_id], $entry['id']);
 								}
 								else {
-									$field_value = strip_tags($field->prepareTableValue($entry['data'][$field_id]));
+									$field_value = $cache[$entry['id']][$field_id] = strip_tags($field->prepareTableValue($entry['data'][$field_id]));
 								}
 							}
 							else {

--- a/lib/class.subsectionmanager.php
+++ b/lib/class.subsectionmanager.php
@@ -136,6 +136,7 @@
 		}
 		
 		function __layoutSubsection($entries, $fields, $caption_template, $droptext_template, $mode, $full) {
+			static $cache = array();
 			$html = array();
 
 			// Templates
@@ -183,11 +184,16 @@
 							$field_id = $field->get('id');
 
 							// Get value
-							if(is_callable(array($field, 'preparePlainTextValue'))) {
-								$field_value = $field->preparePlainTextValue($entry['data'][$field_id], $entry['id']);
+							if (!isset($cache[$entry['id']][$field_id])) {
+								if(is_callable(array($field, 'preparePlainTextValue'))) {
+									$field_value = $field->preparePlainTextValue($entry['data'][$field_id], $entry['id']);
+								}
+								else {
+									$field_value = strip_tags($field->prepareTableValue($entry['data'][$field_id]));
+								}
 							}
 							else {
-								$field_value = strip_tags($field->prepareTableValue($entry['data'][$field_id]));
+								$field_value = $cache[$entry['id']][$field_id];
 							}
 
 							// Caption & Drop text


### PR DESCRIPTION
If some other field also calls `prepareTableValue()` on other fields, it can quickly start recursion between SubsectionManager field and other field. Never ending loop. This fixes the problem by adding local, static cache for prepared values.
