### PR TITLE
Fixed output of field ID attribute and phantom items.

### DIFF
--- a/fields/field.subsectionmanager.php
+++ b/fields/field.subsectionmanager.php
@@ -674,10 +674,6 @@
 			// Generate output			
 			foreach($sorted_id as $entry_id) {
 
-				// Create item
-				$item = new XMLElement('item', NULL, array('id' => $entry_id));
-				$subsection->appendChild($item);
-
 				// Populate entry element
 				$entry = extension_subsectionmanager::$storage['entries'][$entry_id];
 				
@@ -689,6 +685,17 @@
 					$entry = $entry[0];
 					extension_subsectionmanager::$storage['entries'][$entry_id] = $entry;
 				}
+
+				if(empty($entry)) {
+					// TODO: Here we could store deleted ID numbers, and update tbl_fields_stage_sorting later,
+					//       but that would slow things down. Sortorder should be updated whenever entry is deleted.
+					//       So this has to wait for new implementation of sortorder.
+					continue;
+				}
+
+				// Create item
+				$item = new XMLElement('item', NULL, array('id' => $entry_id));
+				$subsection->appendChild($item);
 				
 				// Process entry
 				if(!empty($entry) && !empty(extension_subsectionmanager::$storage['fields'][$context][$this->get('id')])) {

--- a/fields/field.subsectionmanager.php
+++ b/fields/field.subsectionmanager.php
@@ -651,6 +651,8 @@
 			// Create subsection element
 			$entryManager = new EntryManager(Symphony::Engine());
 			$subsection = new XMLElement($this->get('element_name'));
+			$subsection->setAttribute('id', $this->get('id'));
+			$subsection->setAttribute('subsection-id', $this->get('subsection_id'));
 
 			// Get sort order
 			$sorted_id = array();
@@ -678,7 +680,6 @@
 
 				// Populate entry element
 				$entry = extension_subsectionmanager::$storage['entries'][$entry_id];
-				$subsection->setAttribute('id', $entry_id);
 				
 				// Fetch missing entries
 				if(empty($entry)) {


### PR DESCRIPTION
SSM was adding "id" attribute to its element, but that attribute was showing entry_id (and always ended up with last rendered entry).

Second commit is a fix for https://github.com/nilshoerrmann/subsectionmanager/issues/120
