### PR TITLE
Fixed nested SSM fields, ported recursion and async preload fixes from 1.x.

### DIFF
--- a/assets/subsectionmanager.publish.js
+++ b/assets/subsectionmanager.publish.js
@@ -261,7 +261,7 @@
 			};
 			
 			// Browse queue
-			var browse = function() {
+			var browse = function(async) {
 				var list = queue.find('ul');
 
 				// Append queue if it's not present yet
@@ -270,7 +270,7 @@
 
 					// Get queue items
 					$.ajax({
-						async: false,
+						async: (async == true ? true : false),
 						type: 'GET',
 						dataType: 'html',
 						url: Symphony.Context.get('root') + '/symphony/extension/subsectionmanager/get/',
@@ -478,7 +478,7 @@
 		/*-----------------------------------------------------------------------*/
 			
 			// Preload queue items
-			browse();
+			browse(true);
 			
 		});
 

--- a/extension.driver.php
+++ b/extension.driver.php
@@ -190,7 +190,7 @@
 			if(empty($this->entryManager)) {
 				self::$entryManager = new EntryManager(Symphony::Engine());
 			}
-		
+//var_dump("\n<br/>\n<br />*** ".$context['datasource']->dsParamROOTELEMENT."\n<br/>");
 			// Default Data Source
 			if($parent == 'DataSource') {
 				$this->__parseSubsectionFields(
@@ -235,7 +235,7 @@
 			if(!empty($fields)) {
 				foreach($fields as $index => $included) {
 					list($subsection, $field, $remainder) = explode(': ', $included, 3);
-					
+//var_dump("\n<br/>- context: {$context}, subsection: {$subsection}, field: {$field}, reminder: {$reminder}\n<br/>");
 					// Fetch fields
 					if($field != 'formatted' && $field != 'unformatted') {
 	
@@ -244,8 +244,8 @@
 							$this->__fetchFields($section, $context, $subsection, $field, $remainder);
 						}
 						else {
-							$this->__fetchFields($section, $context, $subsection, $field);
-							$this->__parseSubsectionFields(array($field . ': ' . $remainder), $context);
+							$this->__fetchFields($section, $context, $subsection, $field, $context.'/'.$field);
+							$this->__parseSubsectionFields(array($field . ': ' . $remainder), $context.'/'.$field);
 						}
 	
 						// Set a single field call for subsection fields

--- a/extension.driver.php
+++ b/extension.driver.php
@@ -190,7 +190,7 @@
 			if(empty($this->entryManager)) {
 				self::$entryManager = new EntryManager(Symphony::Engine());
 			}
-//var_dump("\n<br/>\n<br />*** ".$context['datasource']->dsParamROOTELEMENT."\n<br/>");
+if ($_GET['debug']==2) var_dump("\n<br/>\n<br />*** ".$context['datasource']->dsParamROOTELEMENT."\n<br/>");
 			// Default Data Source
 			if($parent == 'DataSource') {
 				$this->__parseSubsectionFields(
@@ -226,7 +226,10 @@
 			// Get source
 			$section = 0;
 			if(isset($datasource)) {
-				if(method_exists($datasource, 'getSource')) {
+				if(is_numeric($datasource)) {
+					$section = $datasource;
+				}
+				else if(method_exists($datasource, 'getSource')) {
 					$section = $datasource->getSource();
 				}
 			}
@@ -235,21 +238,23 @@
 			if(!empty($fields)) {
 				foreach($fields as $index => $included) {
 					list($subsection, $field, $remainder) = explode(': ', $included, 3);
-//var_dump("\n<br/>- context: {$context}, subsection: {$subsection}, field: {$field}, reminder: {$reminder}\n<br/>");
+if ($_GET['debug']==2) var_dump("\n<br/>- context: {$context}, subsection: {$subsection}, field: {$field}, reminder: {$reminder}\n<br/>");
 					// Fetch fields
 					if($field != 'formatted' && $field != 'unformatted') {
 	
 						// Get field id and mode
 						if($remainder == 'formatted' || $remainder == 'unformatted' || empty($remainder)) {
+if ($_GET['debug']==2) var_dump("\n<br/>&nbsp;&nbsp;&nbsp;Last\n<br/>");
 							$this->__fetchFields($section, $context, $subsection, $field, $remainder);
 						}
 						else {
-							$this->__fetchFields($section, $context, $subsection, $field, $context.'/'.$field);
-							$this->__parseSubsectionFields(array($field . ': ' . $remainder), $context.'/'.$field);
+if ($_GET['debug']==2) var_dump("\n<br/>&nbsp;&nbsp;&nbsp;Continue\n<br/>");
+							$subsection_id = $this->__fetchFields($section, $context, $subsection, $field, "{$context}/{$subsection}");
+							$this->__parseSubsectionFields(array($field . ': ' . $remainder), "{$context}/{$subsection}", $subsection_id);
 						}
 	
 						// Set a single field call for subsection fields
-						if(isset($datasource)) {
+						if(is_object($datasource)) {
 							unset($datasource->dsParamINCLUDEDELEMENTS[$index]);
 	
 							$storage = $subsection . ': ' . $context;
@@ -300,6 +305,8 @@
 			if(!is_array(self::$storage['fields'][$context][$field_id][$subfield_id])) {
 				self::storeSubsectionFields($context, $field_id, $subfield_id, $mode);
 			}
+
+			return $id[0]['subsection_id'];
 		}
 		
 		/**

--- a/extension.driver.php
+++ b/extension.driver.php
@@ -125,7 +125,7 @@
 			if(!is_null($context['fields']['sort_order'])) {
 			
 				// Delete current sort order
-				$entry_id = $context['entry']->get('id');
+				$entry_id = intval($context['entry']->get('id'));
 				Symphony::Database()->query(
 					"DELETE FROM `tbl_fields_stage_sorting` WHERE `entry_id` = '$entry_id'"
 				);
@@ -141,7 +141,7 @@
 							$order[] = intval($entry);
 						}
 						Symphony::Database()->query(
-							"INSERT INTO `tbl_fields_stage_sorting` (`entry_id`, `field_id`, `order`, `context`) VALUES ('$entry_id', '$field_id', '" . implode(',', $order) . "', 'subsectionmanager')"
+							"INSERT INTO `tbl_fields_stage_sorting` (`entry_id`, `field_id`, `order`, `context`) VALUES ('$entry_id', '".intval($field_id)."', '" . implode(',', $order) . "', 'subsectionmanager')"
 						);
 					}
 				}
@@ -190,7 +190,7 @@
 			if(empty($this->entryManager)) {
 				self::$entryManager = new EntryManager(Symphony::Engine());
 			}
-if ($_GET['debug']==2) var_dump("\n<br/>\n<br />*** ".$context['datasource']->dsParamROOTELEMENT."\n<br/>");
+
 			// Default Data Source
 			if($parent == 'DataSource') {
 				$this->__parseSubsectionFields(
@@ -238,17 +238,15 @@ if ($_GET['debug']==2) var_dump("\n<br/>\n<br />*** ".$context['datasource']->ds
 			if(!empty($fields)) {
 				foreach($fields as $index => $included) {
 					list($subsection, $field, $remainder) = explode(': ', $included, 3);
-if ($_GET['debug']==2) var_dump("\n<br/>- context: {$context}, subsection: {$subsection}, field: {$field}, reminder: {$reminder}\n<br/>");
+
 					// Fetch fields
 					if($field != 'formatted' && $field != 'unformatted') {
 	
 						// Get field id and mode
 						if($remainder == 'formatted' || $remainder == 'unformatted' || empty($remainder)) {
-if ($_GET['debug']==2) var_dump("\n<br/>&nbsp;&nbsp;&nbsp;Last\n<br/>");
 							$this->__fetchFields($section, $context, $subsection, $field, $remainder);
 						}
 						else {
-if ($_GET['debug']==2) var_dump("\n<br/>&nbsp;&nbsp;&nbsp;Continue\n<br/>");
 							$subsection_id = $this->__fetchFields($section, $context, $subsection, $field, "{$context}/{$subsection}");
 							$this->__parseSubsectionFields(array($field . ': ' . $remainder), "{$context}/{$subsection}", $subsection_id);
 						}
@@ -271,11 +269,13 @@ if ($_GET['debug']==2) var_dump("\n<br/>&nbsp;&nbsp;&nbsp;Continue\n<br/>");
 		
 			// Section context
 			if($section !== 0) {
-				$section = " AND t2.`parent_section` = '{$section}' ";				
+				$section = " AND t2.`parent_section` = '".intval($section)."' ";				
 			}
 			else {
-				$section = "";
+				$section = '';
 			}
+
+			$subsection = Symphony::Database()->cleanValue($subsection);
 			
 			// Get id
 			$id = Symphony::Database()->fetch( 
@@ -283,7 +283,7 @@ if ($_GET['debug']==2) var_dump("\n<br/>&nbsp;&nbsp;&nbsp;Continue\n<br/>");
 					FROM `tbl_fields_subsectionmanager` AS t1 
 					INNER JOIN `tbl_fields` AS t2 
 					WHERE t2.`element_name` = '{$subsection}'
-					" . $section . "
+					{$section}
 					AND t1.`field_id` = t2.`id`
 					LIMIT 1) 
 				UNION
@@ -291,7 +291,7 @@ if ($_GET['debug']==2) var_dump("\n<br/>&nbsp;&nbsp;&nbsp;Continue\n<br/>");
 					FROM `tbl_fields_subsectiontabs` AS t1 
 					INNER JOIN `tbl_fields` AS t2 
 					WHERE t2.`element_name` = '{$subsection}'
-					" . $section . "
+					{$section}
 					AND t1.`field_id` = t2.`id`
 					LIMIT 1) 
 				LIMIT 1"

--- a/fields/field.subsectionmanager.php
+++ b/fields/field.subsectionmanager.php
@@ -455,7 +455,7 @@
 				$order = Symphony::Database()->fetchVar('order', 0,
 					"SELECT `order`
 					FROM `tbl_fields_stage_sorting`
-					WHERE `entry_id` = " . $entry_id . "
+					WHERE `entry_id` = " . intval($entry_id) . "
 					AND `field_id` = " . $this->get('id') . "
 					LIMIT 1"
 				);
@@ -655,7 +655,7 @@
 			// Unify data
 			if(empty($data['relation_id'])) $data['relation_id'] = array();
 			if(!is_array($data['relation_id'])) $data['relation_id'] = array($data['relation_id']);
-if ($_GET['debug']==2) var_dump("\n<br />\n<br/>*** appendFormattedElement(mode: {$context}, subsection: ".$this->get('element_name').")\n<br/>");
+
 			// Create subsection element
 			$entryManager = new EntryManager(Symphony::Engine());
 			$subsection = new XMLElement($this->get('element_name'));
@@ -667,7 +667,7 @@ if ($_GET['debug']==2) var_dump("\n<br />\n<br/>*** appendFormattedElement(mode:
 			$order = Symphony::Database()->fetchVar('order', 0,
 				"SELECT `order`
 				FROM `tbl_fields_stage_sorting`
-				WHERE `entry_id` = " . $wrapper->getAttribute('id') . "
+				WHERE `entry_id` = " . intval($wrapper->getAttribute('id')) . "
 				AND `field_id` = " . $this->get('id') . "
 				LIMIT 1"
 			);
@@ -747,7 +747,7 @@ if ($_GET['debug']==2) var_dump("\n<br />\n<br/>*** appendFormattedElement(mode:
 		 */
 		public function fetchAssociatedEntryCount($value){
 			if(isset($value)) {
-				return Symphony::Database()->fetchVar('count', 0, "SELECT count(*) AS `count` FROM `tbl_entries_data_".$this->get('id')."` WHERE `entry_id` = '$value'");
+				return Symphony::Database()->fetchVar('count', 0, "SELECT count(*) AS `count` FROM `tbl_entries_data_".$this->get('id')."` WHERE `entry_id` = '".intval($value)."'");
 			} 
 			else {
 				return 0;

--- a/fields/field.subsectionmanager.php
+++ b/fields/field.subsectionmanager.php
@@ -196,6 +196,9 @@
 			$this->appendRequiredCheckbox($fieldset);
 			$wrapper->appendChild($fieldset);
 
+			// Compatibility with 1.x
+			$wrapper->appendChild(Widget::Input('fields[' . $this->get('sortorder') . '][included_fields]', $this->get('included_fields'), 'hidden'));
+
 		}
 		
 		/**
@@ -353,8 +356,11 @@
 			// Drop text
 			$fields['droptext'] = $this->get('droptext');
 
-			// Data source fields
-			$fields['included_fields'] = (is_null($this->get('included_fields')) ? NULL : implode(',', $this->get('included_fields')));
+			// Data source fields - keep them stored for compatibility with 1.x
+			$included_fields = $this->get('included_fields');
+			if (is_array($included_fields)) $included_fields = implode(',', $included_fields);
+			if (empty($included_fields)) $included_fields = NULL;
+			$fields['included_fields'] = $included_fields;
 
 			// Delete old field settings
 			Symphony::Database()->query(

--- a/fields/field.subsectionmanager.php
+++ b/fields/field.subsectionmanager.php
@@ -655,7 +655,7 @@
 			// Unify data
 			if(empty($data['relation_id'])) $data['relation_id'] = array();
 			if(!is_array($data['relation_id'])) $data['relation_id'] = array($data['relation_id']);
-
+if ($_GET['debug']==2) var_dump("\n<br />\n<br/>*** appendFormattedElement(mode: {$context}, subsection: ".$this->get('element_name').")\n<br/>");
 			// Create subsection element
 			$entryManager = new EntryManager(Symphony::Engine());
 			$subsection = new XMLElement($this->get('element_name'));

--- a/fields/field.subsectionmanager.php
+++ b/fields/field.subsectionmanager.php
@@ -659,7 +659,7 @@
 			// Create subsection element
 			$entryManager = new EntryManager(Symphony::Engine());
 			$subsection = new XMLElement($this->get('element_name'));
-			$subsection->setAttribute('id', $this->get('id'));
+			$subsection->setAttribute('field-id', $this->get('id'));
 			$subsection->setAttribute('subsection-id', $this->get('subsection_id'));
 
 			// Get sort order

--- a/lib/class.subsectionmanager.php
+++ b/lib/class.subsectionmanager.php
@@ -136,6 +136,7 @@
 		}
 		
 		function __layoutSubsection($entries, $fields, $caption_template, $droptext_template, $mode, $full) {
+			static $cache = array();
 			$html = array();
 
 			// Templates
@@ -183,11 +184,17 @@
 							$field_id = $field->get('id');
 
 							// Get value
-							if(is_callable(array($field, 'preparePlainTextValue'))) {
-								$field_value = $field->preparePlainTextValue($entry['data'][$field_id], $entry['id']);
+							if (!isset($cache[$entry['id']][$field_id])) {
+								$cache[$entry['id']][$field_id] = '';
+								if(is_callable(array($field, 'preparePlainTextValue'))) {
+									$field_value = $cache[$entry['id']][$field_id] = $field->preparePlainTextValue($entry['data'][$field_id], $entry['id']);
+								}
+								else {
+									$field_value = $cache[$entry['id']][$field_id] = strip_tags($field->prepareTableValue($entry['data'][$field_id]));
+								}
 							}
 							else {
-								$field_value = strip_tags($field->prepareTableValue($entry['data'][$field_id]));
+								$field_value = $cache[$entry['id']][$field_id];
 							}
 
 							// Caption & Drop text


### PR DESCRIPTION
This patch contains fixes for:
- nested SubsectionManager fields,
- problem with recursion going forever (https://github.com/nilshoerrmann/subsectionmanager/pull/122),
- problem with synchronous preloading (https://github.com/nilshoerrmann/subsectionmanager/pull/125),
- forgetting value of `included_fields` (it should be kept so it can be converted to 2.x later).

It also changes `id` attribute to `field-id` to prevent confusion with entry `id`s and adds some cleanups for values that are used in SQL queries.
