### PR TITLE
Bug fix for drop text not updating on item creation

### DIFF
--- a/assets/subsectionmanager.publish.js
+++ b/assets/subsectionmanager.publish.js
@@ -395,7 +395,7 @@
 						// Update item
 						item.children().not('.destructor').not('.drawer').remove();
 						result.children().prependTo(item);
-						item.attr('class', result.attr('class')).attr('data-value', result.attr('data-value'));
+						item.attr('class', result.attr('class')).attr('data-value', result.attr('data-value')).attr('data-drop', result.attr('data-drop'));
 						stage.trigger('update');
 					}
 				});


### PR DESCRIPTION
New entries created via the ajax stage were not having custom drop text applied until page reload. This commit adds the data-drop attribute for the item after successful creation.
