### PR TITLE
Drop text fix

### DIFF
--- a/assets/subsectionmanager.publish.js
+++ b/assets/subsectionmanager.publish.js
@@ -395,7 +395,7 @@
 						// Update item
 						item.children().not('.destructor').not('.drawer').remove();
 						result.children().prependTo(item);
-						item.attr('class', result.attr('class')).attr('data-value', result.attr('data-value'));
+						item.attr('class', result.attr('class')).attr('data-value', result.attr('data-value')).attr('data-drop', result.attr('data-drop'));
 						stage.trigger('update');
 					}
 				});


### PR DESCRIPTION
Fixes issue where newly created entries would not have custom drop text applied until page reload. Adds the data-drop attribute to the item after successful creation
