### PR TITLE
Defensive check for DS elements.

### DIFF
--- a/fields/field.subsectionmanager.php
+++ b/fields/field.subsectionmanager.php
@@ -825,15 +825,20 @@
 			// Fetch subsection fields
 			$sectionManager = new SectionManager(Symphony::Engine());
 			$section = $sectionManager->fetch($this->get('subsection_id'));
-			$fields = $section->fetchFields();
-
-			foreach($fields as $field) {
-				$field_id = $field->get('id');
-				$elements = $field->fetchIncludableElements(true);
-
-				foreach($elements as $element) {
-					$includable[] = $this->get('element_name') . ': ' . $element;
+			
+			if( $section !== false ){
+				$fields = $section->fetchFields();
+	
+				foreach($fields as $field) {
+					$field_id = $field->get('id');
+					$elements = $field->fetchIncludableElements(true);
+	
+					foreach($elements as $element) {
+						$includable[] = $this->get('element_name') . ': ' . $element;
+					}
 				}
+	
+				$done[$id] -= 1;
 			}
 
 			$done[$id] -= 1;


### PR DESCRIPTION
Make sure section exists before continuing. New / Edit DS throws an error if a Subsection has been deleted but the SSM from parent section still points to it (the section).
