### PR TITLE
JS drag'n'drop fixes

### DIFF
--- a/assets/subsectionmanager.publish.js
+++ b/assets/subsectionmanager.publish.js
@@ -164,7 +164,7 @@
 			
 			// Drag items
 			manager.on('mousedown.subsectionmanager', 'li > header', function(event) {
-				var item = $(event.target).parent('li');
+				var item = $(event.target).closest('.instance');
 				
 				// Don't highlight text
 				event.preventDefault();

--- a/assets/subsectionmanager.publish.js
+++ b/assets/subsectionmanager.publish.js
@@ -473,9 +473,9 @@
 						dropper.fadeOut('fast');
 						dragger.fadeOut('fast');
 						$(document).off('mousemove.subsectionmanager');
-	
+
 						// Drop content
-						textareas.trigger('drop.subsectionmanager', [item]);
+						textareas.filter('.droptarget').trigger('drop.subsectionmanager', [item]);
 						selection.removeClass('dragging');
 					});
 				}


### PR DESCRIPTION
This fixes an issue when you started dragging with the cursor over a child element of `<header>` (e.g. an image). The drag helper would be empty then.
And this fixes an issue that the drop text was added to every textarea on the page regardles of the drop target.
