### PR TITLE
Add creation date attribute to subsection items

### DIFF
--- a/fields/field.subsectionmanager.php
+++ b/fields/field.subsectionmanager.php
@@ -712,7 +712,7 @@
 				}
 
 				// Create item
-				$item = new XMLElement('item', null, array('id' => $entry_id));
+				$item = new XMLElement('item', null, array('id' => $entry_id, 'creation-date' => $entry->creationDate));
 				$subsection->appendChild($item);
 
 				// Process entry for Data Source


### PR DESCRIPTION
Subsection <item> elements only have id attributes, this commit adds a creation-date element with the creation date of the corresponding entry (via the $entry->creationDate method).
