### PR TITLE
Change deprecated method $entry->creationDate for $entry->get() call

### DIFF
--- a/fields/field.subsectionmanager.php
+++ b/fields/field.subsectionmanager.php
@@ -712,7 +712,7 @@
 				}
 
 				// Create item
-				$item = new XMLElement('item', null, array('id' => $entry_id, 'creation-date' => $entry->creationDate));
+				$item = new XMLElement('item', null, array('id' => $entry_id, 'creation-date' => $entry->get('creation_date')));
 				$subsection->appendChild($item);
 
 				// Process entry for Data Source


### PR DESCRIPTION
Replaced the deprecated $entry->creationDate call with the new $entry->get('creation_date') call.
Thanks to Nils for SSM and to Brendan for pointing this out.
