### PR TITLE
CHecking if variable is_array for fetchIncludableElements()

### DIFF
--- a/fields/field.subsectionmanager.php
+++ b/fields/field.subsectionmanager.php
@@ -846,8 +846,10 @@
 				$field_id = $field->get('id');
 				$elements = $field->fetchIncludableElements(true);
 
-				foreach($elements as $element) {
-					$includable[] = $this->get('element_name') . ': ' . $element;
+				if (is_array($elements)) {
+					foreach($elements as $element) {
+						$includable[] = $this->get('element_name') . ': ' . $element;
+					}
 				}
 			}
 


### PR DESCRIPTION
We need to protect ourselves from the code of others. fetchIncludableElements for a publish note returned null.
