### PR TITLE
Work around a bug in jQuery outerHeight() and outerWidth() when called without argument

### DIFF
--- a/assets/subsectionmanager.publish.js
+++ b/assets/subsectionmanager.publish.js
@@ -230,7 +230,7 @@
 				
 				// Resize item
 				subsection.find('#contents > form').on('resize.subsectionmanager', function(event, init) {
-					var height = $(this).outerHeight();
+					var height = $(this).outerHeight(false);
 
 					if(init == true || (!iframe.is('.loading') && content.data('height') !== height && height !== 0)) {
 						resize(content, iframe, body, height);
@@ -504,8 +504,8 @@
 				// Show drop helper
 				textarea.addClass('droptarget');
 				dropper.css({
-					width: textarea.outerWidth(),
-					height: textarea.outerHeight(),
+					width: textarea.outerWidth(false),
+					height: textarea.outerHeight(false),
 					top: offset.top - 4,
 					left: offset.left - 4
 				}).fadeIn('fast');
@@ -598,7 +598,7 @@
 				
 				// Adjust to button width
 				if(controls.length > 0) {
-					browser.css('margin-right', controls.find('button').outerWidth() + 10);
+					browser.css('margin-right', controls.find('button').outerWidth(false) + 10);
 				}
 			}
 			


### PR DESCRIPTION
So apparently the bugs I was experiencing were a combination of my jQuery version and subsectionmanager's JavaScript. The bug is described here:
http://stackoverflow.com/questions/12093806/jquery-1-8-outer-height-width-not-working#answer-15607372

This pull request works around the problem by calling outerHeight and outerWidth with the default argument.

Many thanks to GitHub user houke, who found and fixed this.
